### PR TITLE
Disable upload button during request

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,18 +4,24 @@ import { lambdaApi } from './api/config'
 
 function App() {
   const [file, setFile] = useState<File | null>(null)
+  const [isUploading, setIsUploading] = useState(false)
 
   const handleUpload = async () => {
     if (!file) return
-    const formData = new FormData()
-    formData.append('image', file)
-    await lambdaApi.post('/upload', formData)
+    setIsUploading(true)
+    try {
+      const formData = new FormData()
+      formData.append('image', file)
+      await lambdaApi.post('/upload', formData)
+    } finally {
+      setIsUploading(false)
+    }
   }
 
   return (
     <>
    <input type="file" onChange={(e) => setFile(e.target.files?.[0] || null)} />
-   {file && <button onClick={handleUpload}>Upload</button>}
+   {file && <button onClick={handleUpload} disabled={isUploading}>{isUploading ? 'Uploading...' : 'Upload'}</button>}
    </>
   )
 }


### PR DESCRIPTION
Disable the Upload button during file uploads to prevent multiple submissions and provide user feedback.

---
<a href="https://cursor.com/background-agent?bcId=bc-0870ba99-9c7c-42c5-a6fa-e8a97c0b4a2d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0870ba99-9c7c-42c5-a6fa-e8a97c0b4a2d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Upload button now shows “Uploading...” during the process and is disabled to prevent duplicate submissions.
  - Upload status is accurately tracked, ensuring the button re-enables when finished or if an error occurs.
  - Provides clearer feedback during uploads for a smoother, more reliable experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->